### PR TITLE
Fix unreleasedLabel & compareLink docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ with:
 | `usernamesAsGithubLogins` | Use GitHub tags instead of Markdown links for the author of an issue or pull-request. | [inherit] |
 | `unreleasedOnly` | Generate log from unreleased closed issues only. | [inherit] |
 | `unreleased` | Add to log unreleased closed issues. | [inherit] |
-| `unreleasedLabel` | Include compare link (Full Changelog) between older version and newer version. | [inherit] |
+| `unreleasedLabel` | Set up custom label for unreleased closed issues section. | [inherit] |
+| `compareLink` | Include compare link (Full Changelog) between older version and newer version. | [inherit] |
 | `includeLabels` | Of the labeled issues, only include the ones with the specified labels. | [inherit] |
 | `excludeLabels` | Issues with the specified labels will be excluded from changelog. | [inherit] |
 | `issueLineLabels` | The specified labels will be shown in brackets next to each matching issue. Use "ALL" to show all labels. | [inherit] |

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,9 @@ inputs:
     description: "Add to log unreleased closed issues."
     required: false
   unreleasedLabel:
+    description: "Set up custom label for unreleased closed issues section."
+    required: false
+  compareLink:
     description: "Include compare link (Full Changelog) between older version and newer version."
     required: false
   includeLabels:


### PR DESCRIPTION
### Changes

The description for `unreleasedLabel` was actually describing the `compareLink` option, which was missing from the README. This should fix both issues.

### Implementation details

No code changes, just documentation.

### Additional context

Was trying to find the option name to generate such link, but couldn't find it in the README.